### PR TITLE
feat: add DISPLAY environment variable support for GUI applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Model Context Protocol (MCP) server written in Go that provides secure termina
 - **Secure execution**: Commands run in controlled environment with proper error handling
 - **Platform-aware**: Automatically detects and adapts to the host platform
 - **Flexible shell support**: Configurable shell for command execution
+- **GUI application support**: Automatic DISPLAY environment variable forwarding for X11 applications
 - **Multiple transport modes**: 
   - STDIO mode for traditional MCP clients
   - **🌐 StreamableHTTP transport**: Standards-compliant HTTP-based MCP transport for web integrations
@@ -75,6 +76,27 @@ chmod +x examples/persistent_shell_examples.sh
 2. **persistent_shell** - Execute commands in persistent shell sessions
 3. **session_manager** - Manage shell sessions (list, close)
 
+## Environment Variables
+
+The server supports the following environment variables:
+
+- **`MCP_COMMAND_TIMEOUT`** - Default command timeout in seconds (default: 30)
+- **`MCP_SHELL`** - Custom shell to use for command execution (default: /bin/bash on Unix)
+- **`DISPLAY`** - X11 display for GUI applications (automatically forwarded to commands)
+
+### GUI Application Support
+
+The server automatically forwards the `DISPLAY` environment variable to all executed commands, enabling GUI applications to open on the correct display. This works for both non-persistent commands and persistent shell sessions.
+
+**Example**: Launch a GUI application
+```bash
+# Set DISPLAY when starting the server
+DISPLAY=:0 ./mcp-terminal-server
+
+# GUI applications launched through MCP will use the correct display
+# e.g., xterm, firefox, gedit, etc.
+```
+
 ## Server Endpoints
 
 When running in HTTP mode (`--http` flag), the server provides:
@@ -110,7 +132,8 @@ Add to your `claude_desktop_config.json`:
     "terminal": {
       "command": "/path/to/mcp-terminal-server",
       "env": {
-        "MCP_COMMAND_TIMEOUT": "30"
+        "MCP_COMMAND_TIMEOUT": "30",
+        "DISPLAY": ":0"
       }
     }
   }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	HTTPMode       bool
 	Port           string
 	Host           string
+	Display        string
 }
 
 // NewConfig creates a new configuration with defaults
@@ -67,5 +68,10 @@ func (c *Config) ParseFlags() {
 	// Check for custom shell environment variable
 	if shell := os.Getenv("MCP_SHELL"); shell != "" {
 		c.Shell = shell
+	}
+
+	// Check for DISPLAY environment variable
+	if display := os.Getenv("DISPLAY"); display != "" {
+		c.Display = display
 	}
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -61,6 +62,13 @@ func (e *Executor) Execute(request mcp.CallToolRequest) (*mcp.CallToolResult, er
 		cmd = exec.CommandContext(ctx, shell, "-c", command)
 	default:
 		return mcp.NewToolResultError(fmt.Sprintf("Platform %s not supported", e.config.Platform)), nil
+	}
+
+	// Set up environment variables
+	cmd.Env = os.Environ() // Start with current environment
+	if e.config.Display != "" {
+		// Add or update DISPLAY variable
+		cmd.Env = append(cmd.Env, "DISPLAY="+e.config.Display)
 	}
 
 	var stdout, stderr strings.Builder

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -66,6 +67,13 @@ func (sm *Manager) GetOrCreateSession(sessionID string, shell string) (*ShellSes
 	}
 
 	cmd := exec.Command(shell)
+
+	// Set up environment variables
+	cmd.Env = os.Environ() // Start with current environment
+	if sm.config.Display != "" {
+		// Add or update DISPLAY variable
+		cmd.Env = append(cmd.Env, "DISPLAY="+sm.config.Display)
+	}
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {


### PR DESCRIPTION
Forward the DISPLAY environment variable to executed commands and shell sessions to enable GUI application support. This includes adding the Display field to Config, parsing it from environment, and setting it in both executor and session manager.